### PR TITLE
Refs [TASK][34304] Save Gif At Details Screen

### DIFF
--- a/app/src/main/java/com/sun/imagegif/ui/detail/DetailContract.kt
+++ b/app/src/main/java/com/sun/imagegif/ui/detail/DetailContract.kt
@@ -1,15 +1,19 @@
 package com.sun.imagegif.ui.detail
 
-import com.sun.imagegif.ui.home.HomeContract
+import com.sun.imagegif.data.model.Gif
 import com.sun.imagegif.utils.BasePresenter
 
 interface DetailContract {
 
     interface Presenter : BasePresenter<View> {
+
+        fun saveGif(gif: Gif)
     }
 
-    interface View : HomeContract.View {
-        fun onDetailSuccess()
-        fun onError()
+    interface View {
+
+        fun onSaveGifSuccess(gif: Gif)
+
+        fun onSaveGifError(e: Int)
     }
 }

--- a/app/src/main/java/com/sun/imagegif/ui/detail/DetailFragment.kt
+++ b/app/src/main/java/com/sun/imagegif/ui/detail/DetailFragment.kt
@@ -1,17 +1,34 @@
 package com.sun.imagegif.ui.detail
 
+import android.content.DialogInterface
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
+import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.Fragment
 import com.sun.imagegif.R
 import com.sun.imagegif.data.model.Gif
+import com.sun.imagegif.data.source.local.GifLocalDataSource
+import com.sun.imagegif.data.source.remote.GifRemoteDataSource
+import com.sun.imagegif.data.source.repositories.GifRepository
 import com.sun.imagegif.utils.Constant
-import com.sun.imagegif.utils.loadUrl
+import com.sun.imagegif.utils.loadGifUrl
+import com.sun.imagegif.utils.loadImageUrl
 import kotlinx.android.synthetic.main.fragment_detail.*
 
-class DetailFragment : Fragment() {
+
+class DetailFragment : Fragment(), DetailContract.View {
+
+    private val presenter by lazy {
+        DetailPresenter(
+            GifRepository.getInstance(
+                GifLocalDataSource.getInstance(requireContext()),
+                GifRemoteDataSource.getInstance(),
+            )
+        )
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -27,22 +44,56 @@ class DetailFragment : Fragment() {
         handleEvent()
     }
 
+    override fun onStart() {
+        super.onStart()
+        presenter.setView(this)
+    }
+
+    override fun onSaveGifSuccess(gif: Gif) {
+        Toast.makeText(context, gif.title, Toast.LENGTH_SHORT).show()
+    }
+
+    override fun onSaveGifError(e: Int) {
+        Toast.makeText(context, getString(e), Toast.LENGTH_SHORT).show()
+    }
+
     private fun initViews() {
         initDetailView()
     }
 
     private fun initDetailView() {
-        arguments?.getParcelable<Gif>(Constant.BUNDLE_GIF)?.let {
-            detailsImageView.loadUrl(it.imageUrl)
-            userImageView.loadUrl(it.user.avatarUrl)
-            titleDetailsTextView.text = it.title
-            userNameTextView.text = it.user.name
+        arguments?.getParcelable<Gif>(Constant.BUNDLE_GIF)?.let { gif ->
+            detailsImageView.loadGifUrl(gif.imageUrl)
+            userImageView.loadImageUrl(gif.user.avatarUrl)
+            titleDetailsTextView.text = gif.title
+            userNameTextView.text = gif.user.name
+            downloadImageButton.setOnClickListener {
+                showAlertDialog {
+                    presenter.saveGif(gif)
+                }
+            }
         }
     }
 
     private fun handleEvent() {
         previousImageButton.setOnClickListener {
             fragmentManager?.popBackStack()
+        }
+    }
+
+    private fun showAlertDialog(onAccept: (() -> Unit)) {
+        DialogInterface.OnClickListener { _, type ->
+            when (type) {
+                DialogInterface.BUTTON_POSITIVE -> {
+                    onAccept()
+                }
+            }
+        }.also {
+            AlertDialog.Builder(requireContext()).apply {
+                setMessage(getString(R.string.dialog_download))
+                    .setPositiveButton(getString(R.string.answer_yes), it)
+                    .setNegativeButton(getString(R.string.answer_no), it)
+            }.show()
         }
     }
 

--- a/app/src/main/java/com/sun/imagegif/ui/detail/DetailPresenter.kt
+++ b/app/src/main/java/com/sun/imagegif/ui/detail/DetailPresenter.kt
@@ -1,10 +1,25 @@
 package com.sun.imagegif.ui.detail
 
-import com.sun.imagegif.ui.home.HomeContract
+import com.sun.imagegif.data.model.Gif
+import com.sun.imagegif.data.source.local.OnResultDataListener
+import com.sun.imagegif.data.source.repositories.GifRepository
 
-class DetailPresenter : DetailContract.Presenter {
+class DetailPresenter(private val gifRepository: GifRepository) : DetailContract.Presenter {
 
-    private var view: HomeContract.View? = null
+    private var view: DetailContract.View? = null
+
+    override fun saveGif(gif: Gif) {
+        gifRepository.saveGif(gif, object : OnResultDataListener<Gif> {
+
+            override fun onSuccess(data: Gif) {
+                view?.onSaveGifSuccess(data)
+            }
+
+            override fun onError(e: Int) {
+                view?.onSaveGifError(e)
+            }
+        })
+    }
 
     override fun onStart() = Unit
 

--- a/app/src/main/java/com/sun/imagegif/utils/ImageExt.kt
+++ b/app/src/main/java/com/sun/imagegif/utils/ImageExt.kt
@@ -3,6 +3,15 @@ package com.sun.imagegif.utils
 import android.widget.ImageView
 import com.bumptech.glide.Glide
 
-fun ImageView.loadUrl(url: String) {
-    Glide.with(context).asGif().load(url).into(this)
+fun ImageView.loadGifUrl(url: String) {
+    Glide.with(context)
+        .asGif()
+        .load(url)
+        .into(this)
+}
+
+fun ImageView.loadImageUrl(url: String) {
+    Glide.with(context)
+        .load(url)
+        .into(this)
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,4 +13,7 @@
     <string name="title_storage">Storage</string>
     <string name="delete_failed">Delete failed</string>
     <string name="download_failed">Download failed</string>
+    <string name="dialog_download">Do you want download?</string>
+    <string name="answer_yes">Yes</string>
+    <string name="answer_no">No</string>
 </resources>


### PR DESCRIPTION
## Related Tickets
- [#Task 34304: Save Gif At Details Screen](https://edu-redmine.sun-asterisk.vn/issues/34304)
## WHAT
- Lưu gif vào local khi click button Yes trong dialog 
## Evidence (Screenshot or Video)
![image](https://user-images.githubusercontent.com/68226017/110886624-8a257b80-831b-11eb-97ec-e5d5f702a494.png)
![image](https://user-images.githubusercontent.com/68226017/110886644-91e52000-831b-11eb-942d-b7629582f1b9.png)

## Review Checklist

Category | View Point | Description | Expected Reviewer Answer | Self review | Reviewer2 (name)
--- | --- | --- | --- | --- | ---
Conventions | Does the code follow Sun* coding style and coding conventions? | https://github.com/framgia/coding-standards/tree/master/eng/android | YES |<li>- [ ] yes</li>|<li>- [ ] yes</li>  
Redmine | Does the ticket follow Sun* Redmine working process?  | https://github.com/framgia/Training-Guideline/blob/master/WorkingProcess/redmine/redmine.md| YES |<li>- [ ] yes</li>|<li>- [ ] yes</li>  
Documentation | Is there any incomplete code? If so, should it be removed or flagged with a suitable marker like ‘TODO’? |  | YES |<li>- [ ] yes</li>|<li>- [ ] yes</li>  
## Notes (Optional)