### PR TITLE
Refs [Task] [34305] Show Gifs At Storage Screen

### DIFF
--- a/app/src/main/java/com/sun/imagegif/ui/storage/StorageContract.kt
+++ b/app/src/main/java/com/sun/imagegif/ui/storage/StorageContract.kt
@@ -1,10 +1,17 @@
 package com.sun.imagegif.ui.storage
 
+import com.sun.imagegif.data.model.Gif
 import com.sun.imagegif.utils.BasePresenter
 
 interface StorageContract {
 
-    interface Presenter : BasePresenter<View>
+    interface Presenter : BasePresenter<View> {
 
-    interface View
+        fun getGifsLocal()
+    }
+
+    interface View {
+
+        fun onGetGifsLocalSuccess(data: MutableList<Gif>)
+    }
 }

--- a/app/src/main/java/com/sun/imagegif/ui/storage/StorageFragment.kt
+++ b/app/src/main/java/com/sun/imagegif/ui/storage/StorageFragment.kt
@@ -6,8 +6,27 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import com.sun.imagegif.R
+import com.sun.imagegif.data.model.Gif
+import com.sun.imagegif.data.source.local.GifLocalDataSource
+import com.sun.imagegif.data.source.remote.GifRemoteDataSource
+import com.sun.imagegif.data.source.repositories.GifRepository
+import com.sun.imagegif.ui.detail.DetailFragment
+import com.sun.imagegif.ui.storage.adapter.StorageAdapter
+import com.sun.imagegif.utils.Constant
+import com.sun.imagegif.utils.addFragment
+import kotlinx.android.synthetic.main.fragment_storage.*
 
-class StorageFragment : Fragment() {
+class StorageFragment : Fragment(), StorageContract.View {
+
+    private val storageAdapter by lazy { StorageAdapter() }
+    private val presenter by lazy {
+        StoragePresenter(
+            GifRepository.getInstance(
+                GifLocalDataSource.getInstance(requireContext()),
+                GifRemoteDataSource.getInstance()
+            )
+        )
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -15,6 +34,49 @@ class StorageFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View? {
         return inflater.inflate(R.layout.fragment_storage, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        initViews()
+        handleEvent()
+    }
+
+    override fun onStart() {
+        super.onStart()
+        presenter.run {
+            setView(this@StorageFragment)
+            getGifsLocal()
+        }
+    }
+
+    override fun onGetGifsLocalSuccess(data: MutableList<Gif>) {
+        storageAdapter.updateData(data)
+        swipeRefresh.isRefreshing = false
+    }
+
+    private fun initViews() {
+        initRecyclerViews()
+    }
+
+    private fun initRecyclerViews() {
+        storageRecyclerVIew.adapter = storageAdapter
+    }
+
+    private fun handleEvent() {
+        storageAdapter.setOnClickItemListener(object : StorageAdapter.OnClickItemListener {
+
+            override fun onClickItem(gif: Gif) {
+                addFragment(DetailFragment.newInstance(Bundle().apply {
+                    putParcelable(Constant.BUNDLE_GIF, gif)
+                }), R.id.containerLayout)
+            }
+
+            override fun onDelete(gif: Gif) = Unit
+        })
+        swipeRefresh.setOnRefreshListener {
+            presenter.getGifsLocal()
+        }
     }
 
     companion object {

--- a/app/src/main/java/com/sun/imagegif/ui/storage/StoragePresenter.kt
+++ b/app/src/main/java/com/sun/imagegif/ui/storage/StoragePresenter.kt
@@ -1,8 +1,16 @@
 package com.sun.imagegif.ui.storage
 
-class StoragePresenter : StorageContract.Presenter {
+import com.sun.imagegif.data.source.repositories.GifRepository
+
+class StoragePresenter(private val gifRepository: GifRepository) : StorageContract.Presenter {
 
     private var view: StorageContract.View? = null
+
+    override fun getGifsLocal() {
+        gifRepository.getGifsLocal {
+            view?.onGetGifsLocalSuccess(it)
+        }
+    }
 
     override fun onStart() = Unit
 

--- a/app/src/main/java/com/sun/imagegif/ui/storage/adapter/StorageAdapter.kt
+++ b/app/src/main/java/com/sun/imagegif/ui/storage/adapter/StorageAdapter.kt
@@ -1,0 +1,42 @@
+package com.sun.imagegif.ui.storage.adapter
+
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.sun.imagegif.data.model.Gif
+
+class StorageAdapter : RecyclerView.Adapter<StorageViewHolder>() {
+
+    private val gifs = mutableListOf<Gif>()
+    private var listener: OnClickItemListener? = null
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): StorageViewHolder {
+        return StorageViewHolder(parent).apply {
+            registerItemViewHolderListener(gifs, listener)
+        }
+    }
+
+    override fun onBindViewHolder(holder: StorageViewHolder, position: Int) {
+        holder.onBind(gifs[position])
+    }
+
+    override fun getItemCount() = gifs.size
+
+    fun updateData(items: MutableList<Gif>?) {
+        items?.let {
+            gifs.clear()
+            gifs.addAll(it)
+            notifyDataSetChanged()
+        }
+    }
+
+    fun setOnClickItemListener(listener: OnClickItemListener) {
+        this.listener = listener
+    }
+
+    interface OnClickItemListener {
+
+        fun onClickItem(gif: Gif)
+
+        fun onDelete(gif: Gif)
+    }
+}

--- a/app/src/main/java/com/sun/imagegif/ui/storage/adapter/StorageViewHolder.kt
+++ b/app/src/main/java/com/sun/imagegif/ui/storage/adapter/StorageViewHolder.kt
@@ -1,0 +1,41 @@
+package com.sun.imagegif.ui.storage.adapter
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.sun.imagegif.R
+import com.sun.imagegif.data.model.Gif
+import com.sun.imagegif.utils.loadGifUrl
+import kotlinx.android.synthetic.main.item_gif_search.view.gifImageView
+import kotlinx.android.synthetic.main.item_gif_storage.view.*
+
+class StorageViewHolder(
+    viewGroup: ViewGroup
+) : RecyclerView.ViewHolder(newInstance(viewGroup)) {
+
+    fun onBind(gif: Gif) {
+        itemView.gifImageView.loadGifUrl(gif.imageUrl)
+    }
+
+    fun registerItemViewHolderListener(
+        gifs: MutableList<Gif>,
+        listener: StorageAdapter.OnClickItemListener?
+    ) {
+        with(itemView) {
+            gifImageView.setOnClickListener {
+                listener?.onClickItem(gifs[adapterPosition])
+            }
+            deleteImageButton.setOnClickListener {
+                listener?.onDelete(gifs[adapterPosition])
+            }
+        }
+    }
+
+    companion object {
+        fun newInstance(viewGroup: ViewGroup): View {
+            return LayoutInflater.from(viewGroup.context)
+                .inflate(R.layout.item_gif_storage, viewGroup, false)
+        }
+    }
+}

--- a/app/src/main/res/drawable/ic_delete.xml
+++ b/app/src/main/res/drawable/ic_delete.xml
@@ -1,0 +1,15 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="18dp"
+    android:height="16dp"
+    android:viewportWidth="64"
+    android:viewportHeight="58.67">
+    <path
+        android:fillColor="@color/color_white"
+        android:pathData="M61.33,5.33H48V2.67A2.66,2.66 0,0 0,45.33 0H18.67A2.66,2.66 0,0 0,16 2.67V5.33H2.67a2.67,2.67 0,0 0,0 5.34H8v40a8,8 0,0 0,8 8H48a8,8 0,0 0,8 -8v-40h5.33a2.67,2.67 0,1 0,0 -5.34ZM50.67,50.67A2.67,2.67 0,0 1,48 53.33H16a2.67,2.67 0,0 1,-2.67 -2.66v-40H50.67Z" />
+    <path
+        android:fillColor="@color/color_white"
+        android:pathData="M24,45.33a2.67,2.67 0,0 0,2.67 -2.66V21.33a2.67,2.67 0,0 0,-5.34 0V42.67A2.67,2.67 0,0 0,24 45.33Z" />
+    <path
+        android:fillColor="@color/color_white"
+        android:pathData="M40,45.33a2.67,2.67 0,0 0,2.67 -2.66V21.33a2.67,2.67 0,0 0,-5.34 0V42.67A2.67,2.67 0,0 0,40 45.33Z" />
+</vector>

--- a/app/src/main/res/layout/fragment_storage.xml
+++ b/app/src/main/res/layout/fragment_storage.xml
@@ -2,10 +2,10 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/constraintLayoutStorage"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="@color/color_black_dark"
-    tools:context=".ui.storage.StorageFragment">
+    android:layout_height="wrap_content"
+    android:background="@color/color_black_dark">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/layoutTitleConstraintLayout"
@@ -31,12 +31,12 @@
             app:layout_constraintTop_toTopOf="parent" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 
-    <ScrollView
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+        android:id="@+id/swipeRefresh"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/dp_20"
-        android:paddingHorizontal="@dimen/dp_15"
-        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_height="0dp"
+        android:paddingHorizontal="@dimen/dp_10"
+        app:layout_constraintHeight_percent="0.89"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/layoutTitleConstraintLayout">
 
@@ -47,5 +47,5 @@
             app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
             app:spanCount="2"
             tools:listitem="@layout/item_gif_random" />
-    </ScrollView>
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_gif_storage.xml
+++ b/app/src/main/res/layout/item_gif_storage.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <androidx.cardview.widget.CardView
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:cardCornerRadius="@dimen/dp_10"
+        app:cardUseCompatPadding="true"
+        app:layout_constraintDimensionRatio="190:182"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="@color/color_black_light">
+
+            <androidx.appcompat.widget.AppCompatImageView
+                android:id="@+id/gifImageView"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_marginTop="@dimen/dp_5"
+                android:scaleType="centerCrop"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHeight_percent="0.66"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintWidth_percent="0.94" />
+
+            <androidx.appcompat.widget.AppCompatImageView
+                android:id="@+id/deleteImageButton"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_margin="@dimen/dp_10"
+                android:background="@drawable/custom_circle_button"
+                android:scaleType="centerInside"
+                android:src="@drawable/ic_delete"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintDimensionRatio="1:1"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/gifImageView"
+                app:layout_constraintWidth_percent="0.2" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.cardview.widget.CardView>
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## Related Tickets
- [#Task 34305: Show Gif At Storage Screen](https://edu-redmine.sun-asterisk.vn/issues/34305)
## WHAT
- Hiển thị danh sách các gif ở local
## Evidence (Screenshot or Video)
![image](https://user-images.githubusercontent.com/68226017/110896598-84856100-832e-11eb-859a-77b0f4ff9ef2.png)
![image](https://user-images.githubusercontent.com/68226017/110896629-8e0ec900-832e-11eb-968e-63e1e387ba27.png)

## Review Checklist

Category | View Point | Description | Expected Reviewer Answer | Self review | Reviewer2 (name)
--- | --- | --- | --- | --- | ---
Conventions | Does the code follow Sun* coding style and coding conventions? | https://github.com/framgia/coding-standards/tree/master/eng/android | YES |<li>- [ ] yes</li>|<li>- [ ] yes</li>  
Redmine | Does the ticket follow Sun* Redmine working process?  | https://github.com/framgia/Training-Guideline/blob/master/WorkingProcess/redmine/redmine.md| YES |<li>- [ ] yes</li>|<li>- [ ] yes</li>  
Documentation | Is there any incomplete code? If so, should it be removed or flagged with a suitable marker like ‘TODO’? |  | YES |<li>- [ ] yes</li>|<li>- [ ] yes</li>  
## Notes (Optional)